### PR TITLE
fix Docker warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as build
+FROM node:16 AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm install


### PR DESCRIPTION
Found this warning when running docker build command,
and created a fix ...

```tet
 1 warning found (use docker --debug to expand):
  - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
```